### PR TITLE
安全性改进

### DIFF
--- a/themes/Sakura/layout/_widget/category-items.ejs
+++ b/themes/Sakura/layout/_widget/category-items.ejs
@@ -1,4 +1,4 @@
-<article class="post post-list" itemscope="" itemtype="http://schema.org/BlogPosting">
+<article class="post post-list" itemscope="" itemtype="https://schema.org/BlogPosting">
   <div class="post-entry">
     <div class="feature">
       <a href="<%- url_for(post.path) %>">

--- a/themes/Sakura/layout/_widget/common-article.ejs
+++ b/themes/Sakura/layout/_widget/common-article.ejs
@@ -111,7 +111,7 @@
       </section>
       <%- partial('_partial/comment') %>
       <section class="author-profile">
-        <div class="info" itemprop="author" itemscope="" itemtype="http://schema.org/Person">
+        <div class="info" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
           <a href="<%- post.authorLink %>" class="profile gravatar"><img src="<%- post.avatar%>" itemprop="image" alt="<%- post.author %>" height="70" width="70"></a>
           <div class="meta">
             <span class="title">Author</span>

--- a/themes/Sakura/layout/_widget/common-page.ejs
+++ b/themes/Sakura/layout/_widget/common-page.ejs
@@ -38,7 +38,7 @@
     </article>
       <!-- #post-## -->
       <section class="author-profile">
-        <div class="info" itemprop="author" itemscope="" itemtype="http://schema.org/Person">
+        <div class="info" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
           <a href="/about/" class="profile gravatar"><img src="<%- (theme.cdn || '') + theme.avatar%>" itemprop="image" alt="<%- theme.siteName %>" height="70" width="70"></a>
           <div class="meta">
             <span class="title">Author</span>

--- a/themes/Sakura/layout/_widget/index-items.ejs
+++ b/themes/Sakura/layout/_widget/index-items.ejs
@@ -1,5 +1,5 @@
 <% var external_link = config.external_link ? '_blank' : '_self'; %>
-<article <% if (index%2 == 0){ %> class="post post-list-thumb post-list-thumb-left" <% } %> class="post post-list-thumb" itemscope="" itemtype="http://schema.org/BlogPosting">
+<article <% if (index%2 == 0){ %> class="post post-list-thumb post-list-thumb-left" <% } %> class="post post-list-thumb" itemscope="" itemtype="https://schema.org/BlogPosting">
 
   <div class="post-thumb">
     <a href="<%- url_for(post.path) %>">

--- a/themes/Sakura/layout/donate.ejs
+++ b/themes/Sakura/layout/donate.ejs
@@ -41,7 +41,7 @@
     </footer><!-- .entry-footer -->
   </article>
   <section class="author-profile">
-    <div class="info" itemprop="author" itemscope="" itemtype="http://schema.org/Person">
+    <div class="info" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
       <a href="/about/" class="profile gravatar"><img src="<%- (theme.cdn || '') + theme.avatar%>" itemprop="image" alt="hojun" height="70" width="70"></a>
       <div class="meta">
         <span class="title">Author</span>

--- a/themes/Sakura/layout/links.ejs
+++ b/themes/Sakura/layout/links.ejs
@@ -65,7 +65,7 @@
     </footer><!-- .entry-footer -->
   </article>
   <section class="author-profile">
-    <div class="info" itemprop="author" itemscope="" itemtype="http://schema.org/Person">
+    <div class="info" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
       <a href="/about/" class="profile gravatar"><img src="<%- (theme.cdn || '') + theme.avatar%>" itemprop="image" alt="hojun" height="70" width="70"></a>
       <div class="meta">
         <span class="title">Author</span>


### PR DESCRIPTION
替换所有的http://schema.org 为 https://schema.org 以减少网页混合内容（即https网页出现http内容）
不保证全部替换完了。 