### PR TITLE
update dependencies

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ timezone:
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: /
+#url: /
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:

--- a/package.json
+++ b/package.json
@@ -3,22 +3,23 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.8.0"
+    "version": "6.3.0"
   },
   "dependencies": {
-    "hexo": "^3.7.0",
-    "hexo-deployer-git": "^0.2.0",
-    "hexo-generator-archive": "^0.1.5",
-    "hexo-generator-category": "^0.1.3",
-    "hexo-generator-feed": "^1.2.2",
-    "hexo-generator-index": "^0.2.1",
-    "hexo-generator-json-content": "^2.2.0",
-    "hexo-generator-tag": "^0.2.0",
-    "hexo-git-backup": "^0.1.2",
-    "hexo-renderer-ejs": "^0.3.1",
-    "hexo-renderer-marked": "^0.3.2",
-    "hexo-renderer-stylus": "^0.3.3",
-    "hexo-server": "^0.3.1",
+    "hexo": "^6.3.0",
+    "hexo-cli": "^4.3.1",
+    "hexo-deployer-git": "^4.0.0",
+    "hexo-generator-archive": "^2.0.0",
+    "hexo-generator-category": "^2.0.0",
+    "hexo-generator-feed": "^3.0.0",
+    "hexo-generator-index": "^3.0.0",
+    "hexo-generator-json-content": "^4.2.3",
+    "hexo-generator-tag": "^2.0.0",
+    "hexo-git-backup": "^0.1.3",
+    "hexo-renderer-ejs": "^2.0.0",
+    "hexo-renderer-marked": "^6.1.1",
+    "hexo-renderer-stylus": "^3.0.0",
+    "hexo-server": "^3.0.0",
     "hexo-tag-bili": "^1.0.0",
     "hexo-tag-fancybox_img": "^1.0.1"
   }


### PR DESCRIPTION
原版本在nodejs新版本上不工作。
经使用，在node.js v20.4.0 windows10上运行正常。 
The previous version is too old to work , not fitted in new version of node .
see [al](https://github.com/hexojs/hexo/issues/4268)[so](https://github.com/hexojs/hexo/pull/4285)
