### PR TITLE
替换jsDelivr为国内镜像源加速加载

### DIFF
--- a/themes/Sakura/layout/_partial/aplayer.ejs
+++ b/themes/Sakura/layout/_partial/aplayer.ejs
@@ -1,7 +1,7 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.css">
-<script src="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.js"></script>
+<link rel="stylesheet" href="https://jsd.onmicrosoft.cn/npm/aplayer/dist/APlayer.min.css">
+<script src="https://jsd.onmicrosoft.cn/npm/aplayer/dist/APlayer.min.js"></script>
 <!-- require MetingJS -->
-<script src="https://cdn.jsdelivr.net/npm/meting@2/dist/Meting.min.js"></script>
+<script src="https://jsd.onmicrosoft.cn/npm/meting@2/dist/Meting.min.js"></script>
 <style>
   .aplayer .aplayer-lrc {
     height: 35px;

--- a/themes/Sakura/layout/_partial/comment.ejs
+++ b/themes/Sakura/layout/_partial/comment.ejs
@@ -15,7 +15,7 @@
 <% } %>
 
 <% if (theme.waline.enable && post.comments) { %>
-    <script src="//cdn.jsdelivr.net/npm/@waline/client"></script>
+    <script src="/jsd.onmicrosoft.cn/npm/@waline/client"></script>
     <div id="waline"></div>
     <style>
     #waline textarea {
@@ -33,9 +33,9 @@
               placeholder: '<%= theme.waline.placeholder %>',
               visitor: '<%- theme.waline.visitor %>',
               emoji: [
-                  'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/tieba',
-                  'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/bilibili',
-                  'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/weibo',
+                  'https://jsd.onmicrosoft.cn/gh/walinejs/emojis@1.0.0/tieba',
+                  'https://jsd.onmicrosoft.cn/gh/walinejs/emojis@1.0.0/bilibili',
+                  'https://jsd.onmicrosoft.cn/gh/walinejs/emojis@1.0.0/weibo',
               ],
               avatar: '<%- theme.waline.avatar %>',
               dark: 'auto',

--- a/themes/Sakura/layout/_partial/footer.ejs
+++ b/themes/Sakura/layout/_partial/footer.ejs
@@ -13,8 +13,8 @@
   <div class="site-info">
     <div class="footertext">
       <div class="img-preload">
-        <img src="https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/other/wordpress-rotating-ball-o.svg">
-        <img src="https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/other/disqus-preloader.svg">
+        <img src="https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/other/wordpress-rotating-ball-o.svg">
+        <img src="https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/other/disqus-preloader.svg">
       </div>
       <p style="color: #666666;">&copy 2018</p>
     </div>
@@ -31,7 +31,7 @@
 
 <!-- <script src="/js/tocbot.js"></script> -->
 <script type="text/javascript" src="/js/lib.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
+<script src="https://jsd.onmicrosoft.cn/npm/clipboard@2/dist/clipboard.min.js"></script>
 <script type="text/javascript" src="/js/InsightSearch.js"></script>
 <script type="text/javascript" src="/js/jquery.fancybox.min.js"></script>
 <script type="text/javascript" src="/js/zoom.min.js"></script>

--- a/themes/Sakura/layout/_partial/head.ejs
+++ b/themes/Sakura/layout/_partial/head.ejs
@@ -58,7 +58,7 @@
   mashiro_option.qq_api_url = "https://api.mashiro.top/qqinfo/"; 
   mashiro_option.qq_avatar_api_url = "https://api.mashiro.top/qqinfo/";
 
-  // mashiro_option.jsdelivr_css_src = "https://cdn.jsdelivr.net/gh/moezx/cdn@3.4.5/css/lib.min.css";
+  // mashiro_option.jsdelivr_css_src = "https://jsd.onmicrosoft.cn/gh/moezx/cdn@3.4.5/css/lib.min.css";
   // mashiro_option.float_player_on = true;
 
   /*End of Initial Variables*/

--- a/themes/Sakura/layout/_partial/headertop.ejs
+++ b/themes/Sakura/layout/_partial/headertop.ejs
@@ -12,7 +12,7 @@
         <p><%= theme.description %></p>
         <div class="top-social_v2">
           <li id="bg-pre">
-            <img class="flipx" src="https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/other/next-b.svg">
+            <img class="flipx" src="https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/other/next-b.svg">
           </li>
           <% if (theme.social) {%>
             <% for (i in theme.social) {%>
@@ -35,7 +35,7 @@
             <% } %>
           <% } %>
           <li id="bg-next">
-            <img src="https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/other/next-b.svg">
+            <img src="https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/other/next-b.svg">
           </li>
         </div>
       </div>

--- a/themes/Sakura/layout/_widget/index-items.ejs
+++ b/themes/Sakura/layout/_widget/index-items.ejs
@@ -3,7 +3,7 @@
 
   <div class="post-thumb">
     <a href="<%- url_for(post.path) %>">
-      <img class="lazyload" onerror="imgError(this,3)" src="<%- theme.lazyloadImg%>" data-src="<%= post.photos[0] || 'https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/other/image-404.png' %>">
+      <img class="lazyload" onerror="imgError(this,3)" src="<%- theme.lazyloadImg%>" data-src="<%= post.photos[0] || 'https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/other/image-404.png' %>">
     </a>
   </div>
   <div class="post-content-wrap">

--- a/themes/Sakura/layout/donate.ejs
+++ b/themes/Sakura/layout/donate.ejs
@@ -55,7 +55,7 @@
   </section>
 </div>
   <script src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.0.3.min.js"></script>
-  <!-- <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script> -->
+  <!-- <script src="https://jsd.onmicrosoft.cn/npm/clipboard@2/dist/clipboard.min.js"></script> -->
   <script>
     jQuery(document).ready(function() {
     var QRBox = $('#QRBox');

--- a/themes/Sakura/layout/links.ejs
+++ b/themes/Sakura/layout/links.ejs
@@ -24,7 +24,7 @@
       ★ Name: hojun<br>
       ★ Bio: 好少年光芒万丈<br>
       ★ URL: https://www.hojun.cn<br>
-      ★ Avatar: <a href="https://cdn.jsdelivr.net/gh/honjun/cdn@1.6/img/custom/avatar.jpg" target="_blank" rel="nofollow">
+      ★ Avatar: <a href="https://jsd.onmicrosoft.cn/gh/honjun/cdn@1.6/img/custom/avatar.jpg" target="_blank" rel="nofollow">
       获取嵌入代码</a>
     </p>
     <p style="font-size: 13px">


### PR DESCRIPTION
替换jsDelivr为国内镜像源加速加载
cdn.jsdelivr.net 被墙/污染等原因，使其在国内加载慢，故更改为国内镜像源jsd.onmicrosoft.cn
更多详情可访问其[官网](https://cdn.onmicrosoft.cn/)